### PR TITLE
Fix support for files larger than 4GB

### DIFF
--- a/src/patchelf.cc
+++ b/src/patchelf.cc
@@ -492,7 +492,7 @@ void ElfFile<ElfFileParamNames>::shiftFile(unsigned int extraPages, size_t start
 {
     assert(startOffset >= sizeof(Elf_Ehdr));
 
-    unsigned int oldSize = fileContents->size();
+    auto oldSize = fileContents->size();
     assert(oldSize > startOffset);
 
     /* Move the entire contents of the file after 'startOffset' by 'extraPages' pages further. */


### PR DESCRIPTION
Due to an explicit usage of "unsigned int" when retrieving the size of the file contents, executables larger than 4GB became truncated by shiftFile, eventually leading to a crash.

This commit fixes this issue so the new size of the file is properly computed and the crash no longer happens.